### PR TITLE
Add ruby version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ along with Linaro's jumbo-jekyll-theme.
 
 ## Developing
 
-Install ruby.
-Install jekyll and bundler (`gem install jekyll bundler`)
-Install lkft-website (`bundler install`)
-Build and serve site locally (`bundler exec jekyll serve`)
+* Install ruby >= 2.4.2 (required by jumbo-jekyll-theme).
+* Install jekyll and bundler (`gem install jekyll bundler`)
+* Install lkft-website (`bundler install`)
+* Build and serve site locally (`bundler exec jekyll serve`)
 
 You may also run "make" to build and serve the site locally.
 


### PR DESCRIPTION
jumbo-jekyll-theme requires ruby >= 2.4.2

In additon, render the developing section steps as a list. It's more readable.